### PR TITLE
Update to go1.18. Use generic keys and values

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.18.0-beta1
+        stable: false
 
     - name: Run tests
       run: go test -race ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.18
 
     - name: Run tests
       run: go test -race ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.0-beta1
+        go-version: 1.18
         stable: false
 
     - name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 test:
-	go test ./...
+	go test -race ./...
+
+vet:
+	go vet ./...
 
 format:
 	gofmt -s -w .

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 test:
 	go test -race ./...
 
-vet:
-	go vet ./...
-
 format:
 	gofmt -s -w .

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-test:
-	go test -race ./...
-
-format:
-	gofmt -s -w .

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ Thread-safe Go implementation of a [Least Recently Used cache](https://en.wikipe
 
 ## Usage
 
+The library uses generic Key and Values [recently introduced in Go 1.18](https://tip.golang.org/doc/go1.18).
+
+
+### String example
+
 ```golang
 package main
 
@@ -12,7 +17,7 @@ import (
 )
 
 func main() {
-  cache, err := lru.New(2) // init cache of capacity 2
+  cache, err := lru.New[string, string](2) // init cache of capacity 2
   if err != nil {
     panic(err)
   }
@@ -24,11 +29,43 @@ func main() {
   v := cache.Get("key-1") // nil
   v = cache.Get("key-2") // "value-2" and updates key-2 as most recently used
 }
+```
 
+### Custom struct as value
+
+```golang
+package main
+
+import (
+  lru "github.com/adamjq/lru-cache"
+)
+
+type user struct {
+  userID string
+  name string
+}
+
+func main() {
+  cache, err := lru.New[string, user](2) // instantiate cache with custom types
+  if err != nil {
+    panic(err)
+  }
+
+  userId := "22bc77a3-1456-470f-bdb0-0c893b8778a8"
+
+	key := userId
+	value := user{
+		userID: userId,
+		name: 	"Adam",
+	}
+
+  cache.Put(key, value)
+  v := cache.Get(key) // user
+}
 ```
 
 ## Development
 
 ```bash
-make test
+go test -race ./...
 ```

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ func main() {
 
   userId := "22bc77a3-1456-470f-bdb0-0c893b8778a8"
 
-	key := userId
-	value := user{
-		userID: userId,
-		name: 	"Adam",
-	}
+  key := userId
+  value := user{
+    userID: userId,
+    name: 	"Adam",
+  }
 
   cache.Put(key, value)
   v := cache.Get(key) // user

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/adamjq/lru-cache
 
-go 1.17
+go 1.18
 
 require github.com/stretchr/testify v1.7.0
 

--- a/lru_test.go
+++ b/lru_test.go
@@ -92,7 +92,7 @@ func TestLRUCache_simpleStringKeyStructValue(t *testing.T) {
 
 	type user struct {
 		userID string
-		name string
+		name   string
 	}
 
 	cache, err := New[string, user](2)
@@ -103,7 +103,7 @@ func TestLRUCache_simpleStringKeyStructValue(t *testing.T) {
 	key := mockUserId
 	value := user{
 		userID: mockUserId,
-		name: 	"Adam",
+		name:   "Adam",
 	}
 
 	v := cache.Get(key)

--- a/lru_test.go
+++ b/lru_test.go
@@ -11,30 +11,30 @@ import (
 func TestLRUCache_New_ErrorConditions(t *testing.T) {
 	assert := require.New(t)
 
-	_, err := New[string](0)
+	_, err := New[string, string](0)
 	assert.Error(err)
 
-	_, err = New[string](-5)
+	_, err = New[string, string](-5)
 	assert.Error(err)
 }
 
 func TestLRUCache_New_Generics(t *testing.T) {
 	assert := require.New(t)
 
-	_, err := New[string](1)
+	_, err := New[string, string](1)
 	assert.NoError(err)
 
-	_, err = New[int](1)
+	_, err = New[int, string](1)
 	assert.NoError(err)
 
-	_, err = New[float64](1)
+	_, err = New[float64, string](1)
 	assert.NoError(err)
 }
 
 func TestLRUCache_simpleStringKey(t *testing.T) {
 	assert := require.New(t)
 
-	cache, err := New[string](2)
+	cache, err := New[string, string](2)
 	assert.NoError(err)
 
 	key := "key"
@@ -49,28 +49,77 @@ func TestLRUCache_simpleStringKey(t *testing.T) {
 	assert.Equal(1, len(cache.cache))
 }
 
-func TestLRUCache_simpleIntKey(t *testing.T) {
+func TestLRUCache_simpleIntKeyStringValue(t *testing.T) {
 	assert := require.New(t)
 
-	cache, err := New[int](2)
+	cache, err := New[int, string](2)
 	assert.NoError(err)
 
 	key := 4
+	value := "value"
 
 	v := cache.Get(key)
 	assert.Nil(v)
 	assert.Equal(0, len(cache.cache))
 
-	cache.Put(key, "value")
+	cache.Put(key, value)
 	v = cache.Get(key)
-	assert.Equal(*v, "value")
+	assert.Equal(*v, value)
+	assert.Equal(1, len(cache.cache))
+}
+
+func TestLRUCache_simpleIntKeyFloatValue(t *testing.T) {
+	assert := require.New(t)
+
+	cache, err := New[int, float64](2)
+	assert.NoError(err)
+
+	key := 4
+	value := 5.1
+
+	v := cache.Get(key)
+	assert.Nil(v)
+	assert.Equal(0, len(cache.cache))
+
+	cache.Put(key, value)
+	v = cache.Get(key)
+	assert.Equal(*v, value)
+	assert.Equal(1, len(cache.cache))
+}
+
+func TestLRUCache_simpleStringKeyStructValue(t *testing.T) {
+	assert := require.New(t)
+
+	type user struct {
+		userID string
+		name string
+	}
+
+	cache, err := New[string, user](2)
+	assert.NoError(err)
+
+	mockUserId := "22bc77a3-1456-470f-bdb0-0c893b8778a8"
+
+	key := mockUserId
+	value := user{
+		userID: mockUserId,
+		name: "Adam",
+	}
+
+	v := cache.Get(key)
+	assert.Nil(v)
+	assert.Equal(0, len(cache.cache))
+
+	cache.Put(key, value)
+	v = cache.Get(key)
+	assert.Equal(*v, value)
 	assert.Equal(1, len(cache.cache))
 }
 
 func TestLRUCache_updateSameKey(t *testing.T) {
 	assert := require.New(t)
 
-	cache, err := New[string](2)
+	cache, err := New[string, string](2)
 	assert.NoError(err)
 
 	v := cache.Get("key")
@@ -91,7 +140,7 @@ func TestLRUCache_updateSameKey(t *testing.T) {
 func TestLRUCache_eviction(t *testing.T) {
 	assert := require.New(t)
 
-	cache, err := New[string](2)
+	cache, err := New[string, string](2)
 	assert.NoError(err)
 
 	cache.Put("key-1", "value")
@@ -115,7 +164,7 @@ func TestLRUCache_sequentialPut(t *testing.T) {
 	assert := require.New(t)
 
 	cacheSize := 100
-	cache, err := New[string](cacheSize)
+	cache, err := New[string, string](cacheSize)
 	assert.NoError(err)
 
 	for i := 0; i < cacheSize; i++ {
@@ -128,7 +177,7 @@ func TestLRUCache_sequentialPutExceedsCacheSize(t *testing.T) {
 	assert := require.New(t)
 
 	cacheSize := 100
-	cache, err := New[string](cacheSize)
+	cache, err := New[string, string](cacheSize)
 	assert.NoError(err)
 
 	for i := 0; i < cacheSize*2; i++ {
@@ -141,7 +190,7 @@ func TestLRUCache_concurrentPut(t *testing.T) {
 	assert := require.New(t)
 
 	cacheSize := 500
-	cache, err := New[string](cacheSize)
+	cache, err := New[string, string](cacheSize)
 	assert.NoError(err)
 
 	var wg sync.WaitGroup

--- a/lru_test.go
+++ b/lru_test.go
@@ -8,31 +8,61 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLRUCache_New(t *testing.T) {
+func TestLRUCache_New_ErrorConditions(t *testing.T) {
 	assert := require.New(t)
 
-	_, err := New(0)
+	_, err := New[string](0)
 	assert.Error(err)
 
-	_, err = New(-5)
+	_, err = New[string](-5)
 	assert.Error(err)
+}
 
-	_, err = New(1)
+func TestLRUCache_New_Generics(t *testing.T) {
+	assert := require.New(t)
+
+	_, err := New[string](1)
+	assert.NoError(err)
+
+	_, err = New[int](1)
+	assert.NoError(err)
+
+	_, err = New[float64](1)
 	assert.NoError(err)
 }
 
-func TestLRUCache_simple(t *testing.T) {
+func TestLRUCache_simpleStringKey(t *testing.T) {
 	assert := require.New(t)
 
-	cache, err := New(2)
+	cache, err := New[string](2)
 	assert.NoError(err)
 
-	v := cache.Get("key")
+	key := "key"
+
+	v := cache.Get(key)
 	assert.Nil(v)
 	assert.Equal(0, len(cache.cache))
 
-	cache.Put("key", "value")
-	v = cache.Get("key")
+	cache.Put(key, "value")
+	v = cache.Get(key)
+	assert.Equal(*v, "value")
+	assert.Equal(1, len(cache.cache))
+}
+
+func TestLRUCache_simpleIntKey(t *testing.T) {
+	assert := require.New(t)
+
+	cache, err := New[int](2)
+	assert.NoError(err)
+
+	key := 4
+
+	v := cache.Get(key)
+	assert.Nil(v)
+	assert.Equal(0, len(cache.cache))
+
+	cache.Put(key, "value")
+	v = cache.Get(key)
 	assert.Equal(*v, "value")
 	assert.Equal(1, len(cache.cache))
 }
@@ -40,7 +70,7 @@ func TestLRUCache_simple(t *testing.T) {
 func TestLRUCache_updateSameKey(t *testing.T) {
 	assert := require.New(t)
 
-	cache, err := New(2)
+	cache, err := New[string](2)
 	assert.NoError(err)
 
 	v := cache.Get("key")
@@ -61,7 +91,7 @@ func TestLRUCache_updateSameKey(t *testing.T) {
 func TestLRUCache_eviction(t *testing.T) {
 	assert := require.New(t)
 
-	cache, err := New(2)
+	cache, err := New[string](2)
 	assert.NoError(err)
 
 	cache.Put("key-1", "value")
@@ -85,7 +115,7 @@ func TestLRUCache_sequentialPut(t *testing.T) {
 	assert := require.New(t)
 
 	cacheSize := 100
-	cache, err := New(cacheSize)
+	cache, err := New[string](cacheSize)
 	assert.NoError(err)
 
 	for i := 0; i < cacheSize; i++ {
@@ -98,7 +128,7 @@ func TestLRUCache_sequentialPutExceedsCacheSize(t *testing.T) {
 	assert := require.New(t)
 
 	cacheSize := 100
-	cache, err := New(cacheSize)
+	cache, err := New[string](cacheSize)
 	assert.NoError(err)
 
 	for i := 0; i < cacheSize*2; i++ {
@@ -111,7 +141,7 @@ func TestLRUCache_concurrentPut(t *testing.T) {
 	assert := require.New(t)
 
 	cacheSize := 500
-	cache, err := New(cacheSize)
+	cache, err := New[string](cacheSize)
 	assert.NoError(err)
 
 	var wg sync.WaitGroup

--- a/lru_test.go
+++ b/lru_test.go
@@ -103,7 +103,7 @@ func TestLRUCache_simpleStringKeyStructValue(t *testing.T) {
 	key := mockUserId
 	value := user{
 		userID: mockUserId,
-		name: "Adam",
+		name: 	"Adam",
 	}
 
 	v := cache.Get(key)


### PR DESCRIPTION
This PR updates [the Go version to 1.18](https://tip.golang.org/doc/go1.18) and introduces generic Keys and Values to the cache.

Go `1.18` is currently in a beta release mode so this change should be merged after the official version release.